### PR TITLE
fix catch return value

### DIFF
--- a/Examples/JavaScript/Promise/MyPromise.js
+++ b/Examples/JavaScript/Promise/MyPromise.js
@@ -288,7 +288,7 @@ MyPromise.race = function (promiseList) {
 }
 
 MyPromise.prototype.catch = function (onRejected) {
-  this.then(null, onRejected);
+  return this.then(null, onRejected);
 }
 
 MyPromise.prototype.finally = function (fn) {


### PR DESCRIPTION
根据mdn catch是要返回promise的
这么严重的bug测试为什么不报错呢?  难道这个不是BUG吗?  谢谢...

下面这个测试用例通不过
```js
new Promise((resolve, reject) => {
    throw new Error('Something failed');
})
.catch(() => {
    console.error('Do that');
})
.then(()=>console.log(1))

```